### PR TITLE
Exclude tests in find_packages() in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ recursive-include cnxdb/*-sql *.*
 recursive-include cnxdb/schema *.*
 recursive-include cnxdb/migrations *.py
 recursive-include cnxdb/migrations *.sql
-recursive-include tests/**/data *.*
 recursive-include docs *.*
 recursive-exclude docs/_build *.*
 include versioneer.py

--- a/setup.py
+++ b/setup.py
@@ -47,12 +47,10 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require=extras_require,
-    test_suite='cnxdb.tests',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     package_data={
         'cnxdb': ['*-sql/*.sql', '*-sql/**/*.sql', 'schema/*.json'],
-        'cnxdb.tests': ['data/init/**/*.*'],
         },
     cmdclass=versioneer.get_cmdclass(),
     entry_points="""\


### PR DESCRIPTION
When installing cnx-db, a global "tests" package is also installed.
That is probably not a good idea.  We can fix this by excluding tests in
setup.py.

Also remove tests settings from MANIFEST.in and setup.py.