### PR TITLE
 Include the slug value in tree_to_json results 

### DIFF
--- a/cnxdb/migrations/20190507211827_include_slug_in_tree_to_json.py
+++ b/cnxdb/migrations/20190507211827_include_slug_in_tree_to_json.py
@@ -1,10 +1,8 @@
--- ###
--- Copyright (c) 2013, Rice University
--- This software is subject to the provisions of the GNU Affero General
--- Public License version 3 (AGPLv3).
--- See LICENCE.txt for details.
--- ###
+# -*- coding: utf-8 -*-
 
+
+def up(cursor):
+    cursor.execute("""\
 CREATE OR REPLACE FUNCTION tree_to_json(uuid TEXT, version TEXT, as_collated BOOLEAN DEFAULT TRUE) RETURNS TEXT as $$
 select string_agg(toc,'
 '
@@ -49,40 +47,43 @@ SELECT
 FROM t left join  modules m on t.value = m.module_ident
     WINDOW w as (ORDER BY corder) order by corder ) tree ;
 $$ LANGUAGE SQL;
+""")
 
 
-
-
-
-CREATE OR REPLACE FUNCTION tree_to_json_for_legacy(TEXT, TEXT) RETURNS TEXT AS $$
-SELECT string_agg(toc,'
+def down(cursor):
+    cursor.execute("""\
+CREATE OR REPLACE FUNCTION tree_to_json(uuid TEXT, version TEXT, as_collated BOOLEAN DEFAULT TRUE) RETURNS TEXT as $$
+select string_agg(toc,'
 '
-) FROM (
-WITH RECURSIVE t(node, title, path,value, depth, corder) AS (
-    SELECT nodeid, title, ARRAY[nodeid], documentid, 1, ARRAY[childorder]
+) from (
+WITH RECURSIVE t(node, title, path,value, depth, corder, is_collated) AS (
+    SELECT nodeid, title, ARRAY[nodeid], documentid, 1, ARRAY[childorder],
+           is_collated
     FROM trees tr, modules m
     WHERE m.uuid::text = $1 AND
           module_version( m.major_version, m.minor_version) = $2 AND
       tr.documentid = m.module_ident AND
       tr.parent_id IS NULL AND
-      tr.is_collated = FALSE
+      tr.is_collated = $3
 UNION ALL
-    SELECT c1.nodeid, c1.title, t.path || ARRAY[c1.nodeid], c1.documentid, t.depth+1, t.corder || ARRAY[c1.childorder] /* Recursion */
+    SELECT c1.nodeid, c1.title, t.path || ARRAY[c1.nodeid], c1.documentid, t.depth+1, t.corder || ARRAY[c1.childorder], c1.is_collated /* Recursion */
     FROM trees c1 JOIN t ON (c1.parent_id = t.node)
-    WHERE NOT nodeid = ANY (t.path) AND c1.is_collated = FALSE
+    WHERE not nodeid = any (t.path) AND t.is_collated = c1.is_collated
 )
 SELECT
-    REPEAT('    ', depth - 1) || '{"id":"' || COALESCE(m.moduleid,'subcol') ||  '",' ||
-      '"version":' || COALESCE('"'||m.version||'"', 'null') || ',' ||
+    REPEAT('    ', depth - 1) || 
+    '{"id":"' || COALESCE(m.uuid::text,'subcol') || concat_ws('.','@'||m.major_version, m.minor_version) ||'",' ||
+    '"shortId":"' || COALESCE(short_id(m.uuid),'subcol') || concat_ws('.','@'||m.major_version, m.minor_version) ||'",' ||
       '"title":'||to_json(COALESCE(title,name))||
-      CASE WHEN (depth < lead(depth,1,0) OVER(w)) THEN ', "contents":['
-           WHEN (depth > lead(depth,1,0) OVER(w) AND lead(depth,1,0) OVER(w) = 0 AND m.uuid IS NULL) THEN ', "contents":[]}'||REPEAT(']}',depth - lead(depth,1,0) OVER(w) - 1)
-           WHEN (depth > lead(depth,1,0) OVER(w) AND lead(depth,1,0) OVER(w) = 0 ) THEN '}'||REPEAT(']}',depth - lead(depth,1,0) OVER(w) - 1)
-           WHEN (depth > lead(depth,1,0) OVER(w) AND lead(depth,1,0) OVER(w) != 0 AND m.uuid IS NULL) THEN ', "contents":[]}'||REPEAT(']}',depth - lead(depth,1,0) OVER(w))||','
-           WHEN (depth > lead(depth,1,0) OVER(w) AND lead(depth,1,0) OVER(w) != 0 ) THEN '}'||REPEAT(']}',depth - lead(depth,1,0) OVER(w))||','
+      CASE WHEN (depth < lead(depth,1,0) over(w)) THEN ', "contents":['
+           WHEN (depth > lead(depth,1,0) over(w) AND lead(depth,1,0) over(w) = 0 AND m.uuid IS NULL) THEN ', "contents":[]}'||REPEAT(']}',depth - lead(depth,1,0) over(w) - 1)
+           WHEN (depth > lead(depth,1,0) over(w) AND lead(depth,1,0) over(w) = 0 ) THEN '}'||REPEAT(']}',depth - lead(depth,1,0) over(w) - 1)
+           WHEN (depth > lead(depth,1,0) over(w) AND lead(depth,1,0) over(w) != 0 AND m.uuid IS NULL) THEN ', "contents":[]}'||REPEAT(']}',depth - lead(depth,1,0) over(w))||','
+           WHEN (depth > lead(depth,1,0) over(w) AND lead(depth,1,0) over(w) != 0 ) THEN '}'||REPEAT(']}',depth - lead(depth,1,0) over(w))||','
            WHEN m.uuid IS NULL THEN ', "contents":[]},'
            ELSE '},' END
       AS "toc"
-FROM t LEFT JOIN modules m ON t.value = m.module_ident
-    WINDOW w AS (ORDER BY corder) ORDER BY corder ) tree ;
+FROM t left join  modules m on t.value = m.module_ident
+    WINDOW w as (ORDER BY corder) order by corder ) tree ;
 $$ LANGUAGE SQL;
+""")


### PR DESCRIPTION
Depends on #178, which adds the slug column to the database. This adjusts the `tree_to_json` sql function, which is used for displaying the *book table-of-contents*.

This change will directly influence cnx-archives response data for book based content. The integration tests within archive will need to be updated to address the change made here.