### PR TITLE
Purge varnish cache after transforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requires = (
     'cnx-transforms',
     'psycopg2',
     'sqlalchemy',
+    'requests',
     'rhaptos.cnxmlutils',
     'venusian',
     'zope.deprecation >= 3.5.0',


### PR DESCRIPTION
We transformed the content in the database but the old content continues
to be served because we don't purge the varnish cache.  This purges
everything under /contents/ in archive just to be sure.  Updates to
cnxml-to-html transforms isn't that frequent, and when it is performed,
it is for all the content in the database anyway so this should be ok.