### PR TITLE
Repopulate tree slug values

### DIFF
--- a/cnxdb/migrations/20190502042932_populate_trees_slug_values.py
+++ b/cnxdb/migrations/20190502042932_populate_trees_slug_values.py
@@ -96,6 +96,25 @@ def generate_update_values(nodeid, title):
     return [str(nodeid), slug]
 
 
+def should_run(cursor):
+    # Regenerate the slugs to fix this bug:
+    # https://github.com/openstax/cnx/issues/595
+    #
+    # A specific example is the slug for "Astronomy" ->
+    # "2 Observing the Sky: The Birth of Astronomy" -> "Exercises" ->
+    # "Review Questions" should be "2-review-questions" instead of
+    # "review-questions"
+    cursor.execute("""\
+        SELECT slug FROM trees
+        JOIN modules ON trees.documentid = modules.module_ident
+        WHERE modules.uuid = '1e7cea52-7771-53b4-8957-2d26b35ea373'
+        LIMIT 1""")
+    result = cursor.fetchone()
+    if result:
+        return result[0] == 'review-questions'
+    return False
+
+
 @deferred
 def up(cursor):
     # Create sql function for reducing the dimension of an array

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup_requires = (
     'pytest-runner',
     )
 install_requires = (
-    'cnx-common',
+    'cnx-common >= 1.2.1',
     'cnx-transforms',
     'psycopg2',
     'sqlalchemy',


### PR DESCRIPTION
- Repeat populate tree slug migration

  We adjusted our implementation of generating slugs in cnx-common so we
  need to regenerate all the slugs in the database.
  
  Adding `should_run` in `populate_trees_slug_values` migration means that
  dbmigrator is going to check it to see if this migration should run.
  The condition is based on the bug report we received: if the slug for
  `Astronomy` -> `2 Observing the Sky: The Birth of Astronomy` ->
  `Exercises` -> `Review Questions` is `review-questions` (instead of
  `2-review-questions`), the migration should run.
  
  We can remove the `should_run` from this migration once this has been
  deployed to prod.

- Add cache purging code to populate trees slug migration

  We need to not use the cached result and get archive to generate the
  results to be up to date.
