### PR TITLE
Add twine check on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ script:
   - script/ci_test_dump_restore.sh
   # Test migrations
   - script/ci_test_migrations.sh
+  # Check dist
+  - script/ci_check_dist.sh
 after_success:
   # Report test coverage to codecov.io
   - codecov

--- a/script/ci_check_dist.sh
+++ b/script/ci_check_dist.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pip install twine
+python setup.py bdist_wheel --universal
+twine check dist/*


### PR DESCRIPTION
To avoid tagging and then getting rejected by pypi, we're running twine
check on travis so it will catch all the errors before we upload to
pypi.