### PR TITLE
Separate db_tables function and fixture for reuse

### DIFF
--- a/cnxdb/contrib/pytest.py
+++ b/cnxdb/contrib/pytest.py
@@ -188,14 +188,17 @@ def db_dict_cursor(db_engines, db_settings):
     conn.close()
 
 
-@pytest.fixture
 def db_tables(db_engines):
-    """Provides access to sqlalchemy table objects"""
-    # FIXME put the Tables class in a more common location.
     from .pyramid import _Tables
     tables = _Tables()
     tables.metadata.reflect(bind=db_engines['common'])
     return tables
+
+
+@pytest.fixture(name='db_tables')
+def db_tables_fixture(db_engines):
+    """Provides access to sqlalchemy table objects"""
+    return db_tables(db_engines)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
In cnx-press, the `db_tables` fixture is used as a session fixture
instead of a function fixture but pytest 4.1.0 make it an error to call
a fixture:

```
Fixture "db_tables" called directly. Fixtures are not meant to be called directly,
but are created automatically when test functions request them as parameters.
See https://docs.pytest.org/en/latest/fixture.html for more information about fixtures, and
https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly about how to update your code.
```

One of the solutions suggested by pytest is to separate the function that has
the fixture decorator and the function that returns the fixture.

This fixes cnx-press so it can use the latest version of pytest.