### PR TITLE
Remove upload pypi step in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,9 +40,6 @@ pipeline {
     stage('Publish Release') {
       when { buildingTag() }
       environment {
-        TWINE_CREDS = credentials('pypi-openstax-creds')
-        TWINE_USERNAME = "${TWINE_CREDS_USR}"
-        TWINE_PASSWORD = "${TWINE_CREDS_PSW}"
         release = meta.version()
       }
       steps {
@@ -52,8 +49,6 @@ pipeline {
           sh "docker push openstax/cnx-db:${release}"
           sh "docker push openstax/cnx-db:latest"
         }
-        // Note, '.git' is a volume, because versioneer needs it to resolve the python distribution's version. 
-        sh "docker run --rm -e TWINE_USERNAME -e TWINE_PASSWORD -v ${WORKSPACE}/.git:/src/.git:ro openstax/cnx-db:latest /bin/bash -c \"pip install -q twine && python setup.py bdist_wheel --universal && twine upload dist/*\""
       }
     }
   }


### PR DESCRIPTION
We continue to have problems with jenkins-dev because of the filesystem being
full.  This means either poking devops or uploading to pypi manually.  To avoid
this problem, we are going to use this concourse pipeline to upload to pypi
instead:

https://github.com/openstax/concourse-pipelines/tree/master/pypi-dist-upload

Concourse is better at cleaning up so hopefully we won't see the same problem.